### PR TITLE
Fix filter spinner listener

### DIFF
--- a/src/main/java/com/example/videoclub/controller/AdminControlador.java
+++ b/src/main/java/com/example/videoclub/controller/AdminControlador.java
@@ -98,7 +98,7 @@ public class AdminControlador {
         // Escucha cambios en los filtros y aplica la función filtrarPeliculas()
         tituloFiltroField.textProperty().addListener((observable, oldValue, newValue) -> filtrarPeliculas());
         generoFiltroComboBox.valueProperty().addListener((observable, oldValue, newValue) -> filtrarPeliculas());
-        anioSpinner.valueProperty().addListener((observable, oldValue, newValue) -> filtrarPeliculas());
+        anioFiltroSpinner.valueProperty().addListener((observable, oldValue, newValue) -> filtrarPeliculas());
     }
 
     @FXML


### PR DESCRIPTION
## Summary
- fix an incorrect spinner listener to ensure filtering by year works

## Testing
- `mvn -q -e -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f958dfbc88324a376817cd420d4d3